### PR TITLE
URL에 따라 서비스별 tracker 차단기 분류, 엔터키 바로 이동 및 복사 버튼 추가

### DIFF
--- a/src/pages/project/styles.module.scss
+++ b/src/pages/project/styles.module.scss
@@ -29,11 +29,33 @@
     }
   }
 
-  .textInput {
-    @apply w-[calc(100%-1rem)] mx-2 p-3 rounded-xl 
-      font-medium text-lg text-zinc-900/90 outline-none
+  .inputWrapper {
+    @apply w-[calc(100%-1rem)] mx-2
+      inline-flex justify-evenly items-center;
+
+    .textInput {
+      @apply w-[calc(100%-3.5rem)] p-3 rounded-xl leading-4 border
+        font-medium text-lg text-zinc-900/90 outline-none bg-zinc-300
       selection:bg-zinc-600 selection:text-zinc-100
-      placeholder:italic placeholder:font-light;
+        placeholder:italic placeholder:font-light;
+    }
+
+    .copyButton {
+      @apply w-max h-max p-3 border rounded-full
+        text-center;
+
+      &Enabled {
+        &:hover {
+          @apply bg-rose-500 cursor-wait;
+        }
+      }
+
+      &Disabled {
+        &:hover {
+          @apply bg-zinc-500 cursor-not-allowed;
+        }
+      }
+    }
   }
 
   .textsWrapper {

--- a/src/pages/project/styles.module.scss
+++ b/src/pages/project/styles.module.scss
@@ -22,6 +22,11 @@
   .subtitle {
     @apply w-full p-3 rounded-xl
       font-bold text-2xl select-none;
+
+    .serviceUrl {
+      @apply inline-block
+       font-mono text-rose-500 font-bold;
+    }
   }
 
   .textInput {
@@ -47,7 +52,8 @@
     @apply px-6 py-2;
 
     .description {
-      @apply p-2 border-l-4 border-zinc-500 italic font-serif text-sm;
+      @apply p-2 border-l-4 border-zinc-500 
+      italic font-serif text-sm;
     }
   }
 }

--- a/src/pages/project/styles.module.scss
+++ b/src/pages/project/styles.module.scss
@@ -30,9 +30,10 @@
   }
 
   .textInput {
-    @apply w-full p-3 rounded-xl
+    @apply w-[calc(100%-1rem)] mx-2 p-3 rounded-xl 
       font-medium text-lg text-zinc-900/90 outline-none
-      selection:bg-zinc-600 selection:text-zinc-100;
+      selection:bg-zinc-600 selection:text-zinc-100
+      placeholder:italic placeholder:font-light;
   }
 
   .textsWrapper {

--- a/src/pages/project/url-tracker-blocker.tsx
+++ b/src/pages/project/url-tracker-blocker.tsx
@@ -1,4 +1,5 @@
 import { ChangeEventHandler, KeyboardEventHandler, useEffect, useRef, useState } from 'react';
+import { MdContentCopy } from 'react-icons/md';
 
 import { blockerHostClassifier } from '../../utils/blocker-host-classifier';
 import styles from './styles.module.scss';
@@ -10,10 +11,6 @@ const SAMPLE_URL =
 
 const urlValidator = (url: string) => {
   return /^(http)(s)?:\/\/\S+\.\S+/.test(url);
-};
-
-const copyToClipboard = async (url: string) => {
-  return navigator.clipboard.writeText(url);
 };
 
 /** @todo 컴포넌트 분리 */
@@ -51,13 +48,20 @@ const UrlTrackerBlocker = () => {
     setServiceName(service);
     setDescription(description);
 
-    // TODO: 리스트 추가
+    // TODO: 리스트 추가, 우선 localStorage 활용 -> DB 활용
   };
 
   const handleInputKeyUp: KeyboardEventHandler<HTMLInputElement> = (e) => {
     if (e.key.toLowerCase() === 'enter' && isValidUrl) {
       validUrlAnchorRef.current?.click();
     }
+  };
+
+  const copyToClipboard = async () => {
+    if (!isValidUrl) return;
+
+    navigator.clipboard.writeText(url);
+    alert(`주소가 클립보드에 복사되었습니다`);
   };
 
   useEffect(() => {
@@ -79,14 +83,26 @@ const UrlTrackerBlocker = () => {
           </h2>
         )}
 
-        <input
-          type="text"
-          ref={urlInputRef}
-          onChange={handleInputTextChange}
-          onKeyUp={handleInputKeyUp}
-          className={styles.textInput}
-          placeholder={SAMPLE_URL}
-        />
+        <div className={styles.inputWrapper}>
+          <input
+            type="text"
+            ref={urlInputRef}
+            onChange={handleInputTextChange}
+            onKeyUp={handleInputKeyUp}
+            className={styles.textInput}
+            placeholder={SAMPLE_URL}
+          />
+          <button
+            type="button"
+            className={[
+              styles.copyButton,
+              isValidUrl ? styles.copyButtonEnabled : styles.copyButtonDisabled,
+            ].join(' ')}
+            onClick={copyToClipboard}
+          >
+            <MdContentCopy />
+          </button>
+        </div>
 
         <div className={styles.textsWrapper}>
           <div className={styles.textChanged}>

--- a/src/pages/project/url-tracker-blocker.tsx
+++ b/src/pages/project/url-tracker-blocker.tsx
@@ -1,9 +1,12 @@
-import { ChangeEventHandler, useEffect, useRef, useState } from 'react';
+import { ChangeEventHandler, KeyboardEventHandler, useEffect, useRef, useState } from 'react';
 
 import { blockerHostClassifier } from '../../utils/blocker-host-classifier';
 import styles from './styles.module.scss';
 
+// TODO: constants 파일 분리
 const DEFAULT_DESCRIPTION = `사용자 추적기가 제거된 URL로 이동해봅시다 🚀`;
+const SAMPLE_URL =
+  'https://medium.com/@eliran9692/5-software-architectural-patterns-871e2705c998?source=email-833c7bb9422b-1659808673620-digest.reader-5517fd7b58a6-871e2705c998----0-1------------------469522cf_e322_43b5_b77d_5ca1a56ef975-31';
 
 const urlValidator = (url: string) => {
   return /^(http)(s)?:\/\/\S+\.\S+/.test(url);
@@ -16,6 +19,8 @@ const copyToClipboard = async (url: string) => {
 /** @todo 컴포넌트 분리 */
 const UrlTrackerBlocker = () => {
   const urlInputRef = useRef<HTMLInputElement>(null);
+  const validUrlAnchorRef = useRef<HTMLAnchorElement>(null);
+
   const [url, setUrl] = useState<string>('');
   const [isValidUrl, setIsValidUrl] = useState<boolean>(false);
 
@@ -49,6 +54,12 @@ const UrlTrackerBlocker = () => {
     // TODO: 리스트 추가
   };
 
+  const handleInputKeyUp: KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (e.key.toLowerCase() === 'enter' && isValidUrl) {
+      validUrlAnchorRef.current?.click();
+    }
+  };
+
   useEffect(() => {
     urlInputRef.current?.focus();
   }, [urlInputRef]);
@@ -72,7 +83,9 @@ const UrlTrackerBlocker = () => {
           type="text"
           ref={urlInputRef}
           onChange={handleInputTextChange}
+          onKeyUp={handleInputKeyUp}
           className={styles.textInput}
+          placeholder={SAMPLE_URL}
         />
 
         <div className={styles.textsWrapper}>
@@ -80,7 +93,13 @@ const UrlTrackerBlocker = () => {
             Tracker Blocked URL:
             <br />
             {url && isValidUrl ? (
-              <a className={styles.textChanged} href={url} target="_blank" rel="noreferrer">
+              <a
+                className={styles.textChanged}
+                href={url}
+                target="_blank"
+                rel="noreferrer"
+                ref={validUrlAnchorRef}
+              >
                 {url}
               </a>
             ) : (

--- a/src/utils/blocker-host-classifier/BlockerHostClassifier.ts
+++ b/src/utils/blocker-host-classifier/BlockerHostClassifier.ts
@@ -4,7 +4,7 @@ import { eraseMediumSourceQuery, mediumTrackerDescription } from '../tracker-blo
 
 const BlockerHosts = z.object({
   service: z.string(),
-  host: z.string(),
+  host: z.array(z.string()),
   blocker: z.function().args(z.string()).returns(z.string()),
   description: z.string(),
 });
@@ -14,7 +14,7 @@ type BlockerHosts = z.infer<typeof BlockerHosts>;
 const hosts: BlockerHosts[] = [
   {
     service: 'medium',
-    host: 'medium.com',
+    host: ['medium.com', 'levelup.gitconnected.com'],
     blocker: eraseMediumSourceQuery,
     description: mediumTrackerDescription,
   },
@@ -22,5 +22,5 @@ const hosts: BlockerHosts[] = [
 
 export const blockerHostClassifier = (url: string): BlockerHosts | undefined => {
   const { hostname } = new URL(url);
-  return hosts.find((_currentHost) => _currentHost.host === hostname);
+  return hosts.find((_currentHost) => _currentHost.host.includes(hostname));
 };

--- a/src/utils/blocker-host-classifier/BlockerHostClassifier.ts
+++ b/src/utils/blocker-host-classifier/BlockerHostClassifier.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+import { eraseMediumSourceQuery, mediumTrackerDescription } from '../tracker-blockers';
+
+const BlockerHosts = z.object({
+  service: z.string(),
+  host: z.string(),
+  blocker: z.function().args(z.string()).returns(z.string()),
+  description: z.string(),
+});
+
+type BlockerHosts = z.infer<typeof BlockerHosts>;
+
+const hosts: BlockerHosts[] = [
+  {
+    service: 'medium',
+    host: 'medium.com',
+    blocker: eraseMediumSourceQuery,
+    description: mediumTrackerDescription,
+  },
+];
+
+export const blockerHostClassifier = (url: string): BlockerHosts | undefined => {
+  const { hostname } = new URL(url);
+  return hosts.find((_currentHost) => _currentHost.host === hostname);
+};

--- a/src/utils/blocker-host-classifier/index.ts
+++ b/src/utils/blocker-host-classifier/index.ts
@@ -1,0 +1,1 @@
+export * from './BlockerHostClassifier';

--- a/src/utils/tracker-blockers/index.ts
+++ b/src/utils/tracker-blockers/index.ts
@@ -1,0 +1,1 @@
+export * from './medium';

--- a/src/utils/tracker-blockers/medium.ts
+++ b/src/utils/tracker-blockers/medium.ts
@@ -1,0 +1,6 @@
+export const eraseMediumSourceQuery = (url: string) => {
+  const { protocol, host, pathname } = new URL(url);
+  return new URL(`${protocol}${host}${pathname}`).toString();
+};
+
+export const mediumTrackerDescription = `Medium Daily Digest에 링크된 QueryString 중 source를 제거합니다`;


### PR DESCRIPTION
## URL에 따라 서비스별 Tracker 차단기 분류하여 가져오기

- Medium 뿐만 아니라 타 서비스에 대해서도 url parsing 후 차단할 수 있도록 분류 유틸 추가

## 엔터키 바로이동 추가

- 유효한 Url 인 경우, 주소입력 후 엔터키로 바로 이동

## 복사 버튼 추가

- 유효한 Url 인 경우, 기존200ms 자동 클립보드 복사에서 -> 복사 버튼 활성화로 변경